### PR TITLE
Apply fix for custom registration fields crashing when no option is selected on the frontend-app-authn for `sumac` release.

### DIFF
--- a/custom_reg_form/forms.py
+++ b/custom_reg_form/forms.py
@@ -8,31 +8,92 @@ class ExtraInfoForm(ModelForm):
     """
     def __init__(self, *args, **kwargs):
         super(ExtraInfoForm, self).__init__(*args, **kwargs)
-        self.fields['ethnicity'].error_messages = {
-            "required": u"Please tell us your ethnicity",
-            "invalid": u"Enter correct ethnicity",
-        }
-        self.fields['employment_status'].error_messages = {
-            "required": u"Please tell us your employment status",
-            "invalid": u"Enter correct employment status",
-        }
-        self.fields['zipcode'].error_messages = {
-            "required": u"Please tell us your American ZIP Code",
-            "invalid": u"Invalid American Postal Code (nnnnn or nnnnn-nnnn)",
-        }
-        self.fields['enrolled_in_school'].error_messages = {
-            "required": u"Please tell us if you are enrolled in school",
-            "invalid": u"Enter correct school enrollment status",
-        }
-        self.fields['enrolled_in_school_type'].error_messages = {
-            "required": u"Please tell us about the type of school you are enrolled in",
-            "invalid": u"Enter correct school enrollment type",
-        }
-        self.fields['local_community_living'].error_messages = {
-            "required": u"Please tell us which of the following best describes the place you live now",
-            "invalid": u"Enter correct local community type",
-        }
 
+
+        # Ethnicity
+        # ----------------------------------
+
+        # Remove the Django serialized default of '---------' from the choices
+        field = self.fields['ethnicity']
+        # Keep it optional, but change the placeholder text
+        choices = list(field.choices)
+        if choices and choices[0][0] == "":
+            choices.remove(choices[0])
+        field.choices = choices
+
+        # This is where the error on the `frontend_app_authn` MFE registration form
+        # was causing the page to crash. Previously we had set this to an object.
+        # It just wants a string of dict of strings now.
+        self.fields['ethnicity'].error_messages = u"Select your ethnicity"
+
+
+        # Employment Status
+        # ----------------------------------
+
+        # Remove the Django serialized default of '---------' from the choices
+        field = self.fields['employment_status']
+        # Keep it optional, but change the placeholder text
+        choices = list(field.choices)
+        if choices and choices[0][0] == "":
+            choices.remove(choices[0])
+        field.choices = choices
+
+        # This is where the error on the `frontend_app_authn` MFE registration form
+        # was causing the page to crash. Previously we had set this to an object.
+        # It just wants a string of dict of strings now.
+        self.fields['employment_status'].error_messages = u"Select your employment status"
+        
+        # ZIP Code
+        # ----------------------------------
+        self.fields['zipcode'].error_messages = u"Please tell us your American ZIP Code"
+
+        # Enrolled in School
+        # ----------------------------------
+
+        # Remove the Django serialized default of '---------' from the choices
+        field = self.fields['enrolled_in_school']
+        # Keep it optional, but change the placeholder text
+        choices = list(field.choices)
+        if choices and choices[0][0] == "":
+            choices.remove(choices[0])
+        field.choices = choices
+
+        # This is where the error on the `frontend_app_authn` MFE registration form
+        # was causing the page to crash. Previously we had set this to an object.
+        # It just wants a string of dict of strings now.
+        self.fields['enrolled_in_school'].error_messages = u"Select your enrolled in school status"
+        
+        # Enrolled in School Type
+        # ----------------------------------
+
+        # Remove the Django serialized default of '---------' from the choices
+        field = self.fields['enrolled_in_school_type']
+        # Keep it optional, but change the placeholder text
+        choices = list(field.choices)
+        if choices and choices[0][0] == "":
+            choices.remove(choices[0])
+        field.choices = choices
+
+        # This is where the error on the `frontend_app_authn` MFE registration form
+        # was causing the page to crash. Previously we had set this to an object.
+        # It just wants a string of dict of strings now.
+        self.fields['enrolled_in_school_type'].error_messages = u"Select the type of school you are enrolled in"
+        
+        # Local Community Living
+        # ----------------------------------
+
+        # Remove the Django serialized default of '---------' from the choices
+        field = self.fields['local_community_living']
+        # Keep it optional, but change the placeholder text
+        choices = list(field.choices)
+        if choices and choices[0][0] == "":
+            choices.remove(choices[0])
+        field.choices = choices
+
+        # This is where the error on the `frontend_app_authn` MFE registration form
+        # was causing the page to crash. Previously we had set this to an object.
+        # It just wants a string of dict of strings now.
+        self.fields['local_community_living'].error_messages = u"Select the place that describes where you live now"
 
     class Meta(object):
         model = ExtraInfo

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup
 
 setup(
     name='custom-form-app',
-    version='1.0',
+    version='1.1',
     description='LMS - Custom Registration Extension Form',
     packages=['custom_reg_form'],
     install_requires=[


### PR DESCRIPTION
For the custom fields that we created with this repo, the new frontend-app-authn React frontend was crashing due to the incorrect fields.error_messages being assigned to an Object when a single string value was needed.

Also, removed the default '---------' for an empty field. This was not related to the crash but was necessary because Django added this in for an empty field value.